### PR TITLE
DW-5439 Add sshd SFTP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-MAINTAINER Casey Rogers
+LABEL MAINTAINER "Casey Rogers"
 
 RUN apk update \ 
     &&  apk upgrade
@@ -9,9 +9,20 @@ RUN apk add x11vnc xvfb supervisor \
     && addgroup alpine \
     && adduser  -G alpine -u 1001 -s /bin/sh -D alpine \
     && echo "alpine:alpine" | /usr/sbin/chpasswd \
-    && apk add --no-cache python3 libstdc++ chromium harfbuzz nss freetype ttf-freefont
+    && apk add --no-cache python3 libstdc++ chromium harfbuzz nss freetype ttf-freefont \
+    && mkdir -p /var/log/supervisord \
+    && chown -R alpine:alpine /var/log/supervisord
+
+RUN apk add openssh openssh-sftp-server openssh-server-pam \
+    && mkdir -p /var/run/sshd  \
+    && rm -f /etc/ssh/ssh_host_*key* \
+    && chown -R alpine:alpine /etc/ssh \
+    && mkdir -p /var/run/sftp \
+    && chown -R alpine:alpine /var/run/sftp \
+    && echo "alpine" > "/var/run/sftp/users.conf"
 
 COPY etc/supervisord.conf /etc/supervisord.conf
+COPY etc/sshd_config /etc/ssh/sshd_config
 COPY --chown=alpine:alpine startup.sh /home/alpine/startup.sh
 
 RUN chmod u+x /home/alpine/startup.sh
@@ -19,6 +30,7 @@ RUN chmod u+x /home/alpine/startup.sh
 WORKDIR /home/alpine
 
 EXPOSE 5900
+EXPOSE 22
 
 USER alpine
 

--- a/etc/sshd_config
+++ b/etc/sshd_config
@@ -1,0 +1,23 @@
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+Protocol 2
+
+UseDNS no
+
+PidFile /var/run/sshd/sshd.pid
+
+# Limit access
+PermitRootLogin no
+X11Forwarding no
+AllowTcpForwarding no
+
+# Only allow sftp
+Subsystem sftp internal-sftp
+ForceCommand internal-sftp
+# ChrootDirectory %h # Not working without suid
+
+# Only allow pubkey authentication
+UsePAM yes
+ChallengeResponseAuthentication no
+PasswordAuthentication no
+

--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+childlogdir=/var/log/supervisord
+
 [program:xvfb]
 command=/usr/bin/Xvfb :1 -screen 0 %(ENV_VNC_SCREEN_SIZE)sx24
 autorestart=true
@@ -18,6 +20,12 @@ command=/usr/bin/chromium-browser %(ENV_CHROME_OPTS)s
 user=alpine
 autorestart=true
 priority=300
+
+[program:sshd]
+command=/usr/sbin/sshd -D -e
+user=alpine
+autorestart=true
+priority=400
 
 [unix_http_server]
 file=/home/alpine/supervisord.sock

--- a/startup.sh
+++ b/startup.sh
@@ -10,4 +10,21 @@ if [ -z "$NO_PROXY" ]; then
     export NO_PROXY="";
 fi;
 
+# Generate unique ssh keys for this container, if needed
+if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ''
+fi
+if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+    ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ''
+fi
+
+chmod 600 /etc/ssh/ssh_host_ed25519_key || true
+chmod 600 /etc/ssh/ssh_host_rsa_key || true
+
+if [ ! -z "$SFTP_PUBLIC_KEY" ]; then
+    echo "Adding authorized SFTP public key"
+    mkdir -p "$HOME/.ssh"
+    echo "$SFTP_PUBLIC_KEY" >> $HOME/.ssh/authorized_keys
+fi;
+
 /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
This PR adds an SFTP server to the chrome image. It is configured to only allow SFTP connections (no SSH) with limited access (no root logins, no x11 or tcp forwarding). Only pubkey authentication is allowed.